### PR TITLE
added pseudo code for possible implementation of getRandomizedRecipes

### DIFF
--- a/src/main/kotlin/edu/byu/mealplanningassistant/services/MealPlanGenerator.kt
+++ b/src/main/kotlin/edu/byu/mealplanningassistant/services/MealPlanGenerator.kt
@@ -1,0 +1,22 @@
+package edu.byu.mealplanningassistant.services
+
+import edu.byu.mealplanningassistant.models.GetRandomizedRecipesRequest
+import edu.byu.mealplanningassistant.models.GetRandomizedRecipesResponse
+
+class MealPlanGenerator {
+    fun getRandomizedRecipes(getRandomizedRecipesRequest: GetRandomizedRecipesRequest) : GetRandomizedRecipesResponse {
+        TODO()
+        /**
+         * queryRecordsInRandomOrder().forEach {
+         *      if it.matches(getRandomizedRecipeRequests.requests.any()) {
+         *          assign(it to the first recipe request that matches that has no recipes assigned)
+         *      }
+         *      if all recipe requests are filled {
+         *          break
+         *      }
+         * }
+         *
+         * format in a GetRandomizedRecipesResponse and return
+         */
+    }
+}


### PR DESCRIPTION
An idea hit me during class for how we could build the randomizer in a way that would _not_ require the ability to query by every kind of attribute. I wanted to write this idea down and present it to the team before I forgot it and also explain some of my reasoning.

The reason that we are scanning in a random order is that this `random` can be replaced with different scanning priorities in the future. Perhaps, we add a `"ratings"` field to recipes in the future and want to put the highest rated recipes that fit the requirements first. We can add other attributes that we can query by in the future, should we choose.

A second benefit is that this will allow for the `matches()` function to contain more logic than just matching a string attribute, but also a nutrient requirement or a lack of a certain ingredient (etc.) should we choose to add such features in the future.

Please be critical of this as I think that the way this logic is implemented will greatly inhibit or enhance our ability to change features later.